### PR TITLE
Use verbosity=Verbosity.VERBOSE for io.write_line

### DIFF
--- a/poetry_version_plugin/plugin.py
+++ b/poetry_version_plugin/plugin.py
@@ -3,7 +3,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from cleo.io.io import IO
+from cleo.io.io import IO, Verbosity
 from poetry.plugins.plugin import Plugin
 from poetry.poetry import Poetry
 from poetry.utils.helpers import module_name
@@ -50,7 +50,8 @@ class VersionPlugin(Plugin):  # type: ignore
             else:
                 io.write_line(
                     "<b>poetry-version-plugin</b>: Using __init__.py file at "
-                    f"{init_path} for dynamic version"
+                    f"{init_path} for dynamic version",
+                    verbosity=Verbosity.VERBOSE
                 )
             tree = ast.parse(init_path.read_text())
             for el in tree.body:
@@ -72,7 +73,8 @@ class VersionPlugin(Plugin):  # type: ignore
                                 io.write_line(
                                     "<b>poetry-version-plugin</b>: Setting package "
                                     "dynamic version to __version__ "
-                                    f"variable from __init__.py: <b>{version}</b>"
+                                    f"variable from __init__.py: <b>{version}</b>",
+                                    verbosity=Verbosity.VERBOSE
                                 )
                                 poetry.package.set_version(version)
                                 return
@@ -93,7 +95,8 @@ class VersionPlugin(Plugin):  # type: ignore
                 tag = result.stdout.strip()
                 io.write_line(
                     "<b>poetry-version-plugin</b>: Git tag found, setting "
-                    f"dynamic version to: {tag}"
+                    f"dynamic version to: {tag}",
+                    verbosity=Verbosity.VERBOSE
                 )
                 poetry.package.set_version(tag)
                 return


### PR DESCRIPTION
This PR ensures that `poetry version -s` prints the project version number (and nothing else).

Shell scripts often use `poetry version -s` to get the current project version number. However, `poetry-version-plugin` breaks this idiom by printing out extra log messages:

```
$ poetry version -s
poetry-version-plugin: Using __init__.py file at sgap/__init__.py for dynamic version
poetry-version-plugin: Setting package dynamic version to __version__ variable from __init__.py: 0.1.0
0.1.0
```

After merging this PR:

- `poetry version -s` will print just the version number (e.g. `0.1.0`)
- `poetry version -s -v` will print the extra log messages (since `--verbose` is specified)

Closes #12.