### PR TITLE
Add pipx installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ $ poetry plugin add poetry-version-plugin
 --> 100%
 ```
 
+Or install this plugin to your Poetry with pipx:
+
+```console
+$ pipx inject poetry poetry-version-plugin
+
+--> 100%
+```
+
 ### Set version in init file
 
 Set your package version in your file `__init__.py`, for example:


### PR DESCRIPTION
Hi, this is the first plugin I tried to install into poetry and I noticed there is a different approach when poetry is installed with `pipx`.

https://python-poetry.org/docs/master/plugins/#with-pipx-inject