### PR TITLE
✨ Add support for Poetry 1.2.0 and above (including 1.5.1), deprecate support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9"]
       fail-fast: false
     
     steps:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It won't be helpful in other use cases like managing local app environments with
 
 ## How to use
 
-Make sure you have Poetry version `1.2.0a1` or above. Read below for instructions to install it if you haven't.
+Make sure you have Poetry version `1.2.0rc2` or above. Read below for instructions to install it if you haven't.
 
 ### Install Poetry Version Plugin
 
@@ -206,11 +206,11 @@ So, you could only create each version in a Git tag (for example, a GitHub relea
 
 And then build the package on Continuous Integration (e.g. GitHub Actions). And this plugin would get the version of the package from that Git tag.
 
-## Install Poetry `1.2.0a1`
+## Install Poetry `1.2.0rc2`
 
-For this plugin to work, you need Poetry version `1.2.0a1` or above.
+For this plugin to work, you need Poetry version `1.2.0rc2` or above.
 
-[Poetry `1.2.0a1` was released recently](https://python-poetry.org/blog/announcing-poetry-1-2-0a1.html).
+[Poetry `1.2.0rc2` was released recently](https://python-poetry.org/blog/announcing-poetry-1.2.0rc2/).
 
 There's a high chance you already have installed Poetry `1.1.x`.
 
@@ -234,13 +234,13 @@ $ python install-poetry.py --preview
 --> 100%
 ```
 
-🔍 Notice that the new installer file is named `install-poetry.py` instead of `get-poetry.py`. Also, notice that, currently, you need to set `--preview` for it to install the alpha version `1.2.0a1`.
+🔍 Notice that the new installer file is named `install-poetry.py` instead of `get-poetry.py`. Also, notice that, currently, you need to set `--preview` for it to install the alpha version `1.2.0rc2`.
 
 You can check that it worked with:
 
 ```console
 $ poetry --version
-Poetry (version 1.2.0a1)
+Poetry (version 1.2.0rc2)
 ```
 
 ## Support for version in init file

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It won't be helpful in other use cases like managing local app environments with
 
 ## How to use
 
-Make sure you have Poetry version `1.2.0rc2` or above. Read below for instructions to install it if you haven't.
+Make sure you have Poetry version `1.2.0` or above. Read below for instructions to install it if you haven't.
 
 ### Install Poetry Version Plugin
 
@@ -137,7 +137,7 @@ authors = ["Rick Sanchez <rick@rick-citadel.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 
 [build-system]
 requires = ["poetry-core"]
@@ -206,11 +206,11 @@ So, you could only create each version in a Git tag (for example, a GitHub relea
 
 And then build the package on Continuous Integration (e.g. GitHub Actions). And this plugin would get the version of the package from that Git tag.
 
-## Install Poetry `1.2.0rc2`
+## Install Poetry `1.2.0`
 
-For this plugin to work, you need Poetry version `1.2.0rc2` or above.
+For this plugin to work, you need Poetry version `1.2.0` or above.
 
-[Poetry `1.2.0rc2` was released recently](https://python-poetry.org/blog/announcing-poetry-1.2.0rc2/).
+[Poetry `1.2.0` was released recently](https://python-poetry.org/blog/announcing-poetry-1.2.0/).
 
 There's a high chance you already have installed Poetry `1.1.x`.
 
@@ -234,13 +234,13 @@ $ python install-poetry.py --preview
 --> 100%
 ```
 
-🔍 Notice that the new installer file is named `install-poetry.py` instead of `get-poetry.py`. Also, notice that, currently, you need to set `--preview` for it to install the alpha version `1.2.0rc2`.
+🔍 Notice that the new installer file is named `install-poetry.py` instead of `get-poetry.py`. Also, notice that, currently, you need to set `--preview` for it to install the alpha version `1.2.0`.
 
 You can check that it worked with:
 
 ```console
 $ poetry --version
-Poetry (version 1.2.0rc2)
+Poetry (version 1.2.0)
 ```
 
 ## Support for version in init file

--- a/poetry_version_plugin/plugin.py
+++ b/poetry_version_plugin/plugin.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 from cleo.io.io import IO
 from poetry.plugins.plugin import Plugin
 from poetry.poetry import Poetry
-from poetry.utils.helpers import module_name
+from poetry.core.utils.helpers import module_name
 
 
 class VersionPlugin(Plugin):  # type: ignore
@@ -74,7 +74,7 @@ class VersionPlugin(Plugin):  # type: ignore
                                     "dynamic version to __version__ "
                                     f"variable from __init__.py: <b>{version}</b>"
                                 )
-                                poetry.package.set_version(version)
+                                poetry.package._set_version(version)
                                 return
             message = (
                 "<b>poetry-version-plugin</b>: No valid __version__ variable found "
@@ -95,7 +95,7 @@ class VersionPlugin(Plugin):  # type: ignore
                     "<b>poetry-version-plugin</b>: Git tag found, setting "
                     f"dynamic version to: {tag}"
                 )
-                poetry.package.set_version(tag)
+                poetry.package._set_version(tag)
                 return
             else:
                 message = (

--- a/poetry_version_plugin/plugin.py
+++ b/poetry_version_plugin/plugin.py
@@ -4,12 +4,12 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from cleo.io.io import IO
+from poetry.core.utils.helpers import module_name
 from poetry.plugins.plugin import Plugin
 from poetry.poetry import Poetry
-from poetry.core.utils.helpers import module_name
 
 
-class VersionPlugin(Plugin):  # type: ignore
+class VersionPlugin(Plugin):
     def activate(self, poetry: Poetry, io: IO) -> None:
         poetry_version_config: Optional[Dict[str, Any]] = poetry.pyproject.data.get(
             "tool", {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,13 +33,13 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-poetry = "^1.2.0rc2"
+poetry = "^1.2.0"
 
 [tool.poetry.dev-dependencies]
+mypy = "^1.4.1"
 pytest = "^7.1.2"
-mypy = "^0.812"
 flake8 = "^3.9.2"
-black = {version = "^21.5-beta.1", python = ">3.6.2"}
+black = "^23.3.0"
 coverage = {extras = ["toml"], version = "^5.5"}
 pkginfo = "^1.7.0"
 autoflake = "^1.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Topic :: System :: Software Distribution",
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-version-plugin"
-version = "0.1.3"
+version = "0.2.0"
 description = "Poetry plugin for dynamically extracting the package version from a __version__ variable or a Git tag."
 authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 homepage = "https://github.com/tiangolo/poetry-version-plugin"
@@ -33,11 +33,11 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
-poetry = "^1.2.0a1"
+python = "^3.7"
+poetry = "^1.2.0rc2"
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.2"
+pytest = "^7.1.2"
 mypy = "^0.812"
 flake8 = "^3.9.2"
 black = {version = "^21.5-beta.1", python = ">3.6.2"}


### PR DESCRIPTION
The goal of this PR is to resolve issues documented in #27 and compatibility issues mentioned in #25.

This PR resolves:
- a bad method reference to `module_name` in `poetry.utils.helpers@module_name` which is now only available via `poetry.core.utils.helpers@module_name` 
- invalid method exception encountered on `set_version` as it was recently removed and rewritten to handle hashing under poetry.core's `ProjectPackage._set_version(version, pretty_version)`

Additionally, this PR updates some dependencies to allow `pytest`  to execute under Python 3.10.

Tests are passing with the provided changes.

Related to #27 and #25 (probably fixes them)