### PR TITLE
⬆️ Deprecate Python 3.6 and add CI for latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,12 @@ name: Test
 
 on:
   push:
+    branches:
+      - master
   pull_request:
-    types: [opened, synchronize]
+    types: 
+      - opened
+      - synchronize
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -58,3 +62,15 @@ jobs:
         run: python -m poetry run bash scripts/test.sh
       - name: Upload coverage
         uses: codecov/codecov-action@v1
+
+  # https://github.com/marketplace/actions/alls-green#why
+  check:  # This job does nothing and is only used for the branch protection
+    if: always()
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     
     steps:

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ You could manually write the `__version__` variable and handle the synchronizati
 
 The current [official way of doing it without duplicating the value](https://github.com/python-poetry/poetry/pull/2366#issuecomment-652418094) is with `importlib.metadata`.
 
-But that module is only available in Python 3.8 and above. So, for Python 3.7 and 3.6 you have to install a backport as a dependency of your package:
+But that module is only available in Python 3.8 and above. So, for Python 3.7 you have to install a backport as a dependency of your package:
 
 ```toml
 [tool.poetry.dependencies]

--- a/tests/assets/custom_packages/pyproject.toml
+++ b/tests/assets/custom_packages/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "custom_package"}]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/assets/git_tag/pyproject.toml
+++ b/tests/assets/git_tag/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/assets/multiple_packages/pyproject.toml
+++ b/tests/assets/multiple_packages/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "custom_package"}, {include = "custom_packageb"}]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/assets/no_config/pyproject.toml
+++ b/tests/assets/no_config/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/assets/no_config_source/pyproject.toml
+++ b/tests/assets/no_config_source/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/assets/no_packages/pyproject.toml
+++ b/tests/assets/no_packages/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/assets/no_standard_dir/pyproject.toml
+++ b/tests/assets/no_standard_dir/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "test_custom_version", from = "src"}]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/assets/no_version_var/pyproject.toml
+++ b/tests/assets/no_version_var/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/assets/variations/pyproject.toml
+++ b/tests/assets/variations/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
⬆️ Deprecate Python 3.6 and add CI for latest versions